### PR TITLE
Path fixes for Raspbian Bookworm

### DIFF
--- a/manifests/cmdline.pp
+++ b/manifests/cmdline.pp
@@ -11,6 +11,8 @@ class pi::cmdline (
   Hash[String[1], Hash] $parameters = {},
   Boolean $reboot = true,
 ) {
+  include pi::params
+
   $path = "${pi::params::path}/cmdline.txt"
 
   augeas::lens { 'boot_cmdline':

--- a/manifests/cmdline.pp
+++ b/manifests/cmdline.pp
@@ -11,6 +11,8 @@ class pi::cmdline (
   Hash[String[1], Hash] $parameters = {},
   Boolean $reboot = true,
 ) {
+  $path = "${pi::params::path}/cmdline.txt"
+
   augeas::lens { 'boot_cmdline':
     lens_content => file("${module_name}/boot_cmdline.aug"),
   }
@@ -22,9 +24,9 @@ class pi::cmdline (
   }
 
   if ($reboot) {
-    reboot { '/boot/cmdline.txt':
+    reboot { $path`:
       apply   => finished,
-      message => 'Rebooting to apply /boot/config.txt changes',
+      message => "Rebooting to apply ${path} changes",
       when    => refreshed,
     }
   }

--- a/manifests/cmdline/parameter.pp
+++ b/manifests/cmdline/parameter.pp
@@ -19,9 +19,9 @@ define pi::cmdline::parameter (
   }
 
   augeas { $name:
-    context => '/files/boot/cmdline.txt/1',
+    context => "/files${pi::cmdline::path}/1",
     lens    => 'Boot_Cmdline.lns',
-    incl    => '/boot/cmdline.txt',
+    incl    => $pi::cmdline::path,
     changes => [
       "set parameter[. = '${_real_parameter}'] '${_real_parameter}'",
     ],
@@ -29,6 +29,6 @@ define pi::cmdline::parameter (
   }
 
   if Class['pi::cmdline']['reboot'] {
-    Augeas[$name] ~> Reboot['/boot/cmdline.txt']
+    Augeas[$name] ~> Reboot[$pi::cmdline::path]
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,7 +12,9 @@ class pi::config (
   Hash[String[1], Hash] $fragments = {},
   Boolean $reboot = true,
 ) {
-  concat { '/boot/config.txt':
+  $path = "${::pi::params::path}/config.txt"
+
+  concat { $path:
     ensure => present,
     mode   => '0755',  # this is the default, +x seems odd
   }
@@ -24,9 +26,9 @@ class pi::config (
   }
 
   if ($reboot) {
-    reboot { '/boot/config.txt':
+    reboot { $path:
       apply   => finished,
-      message => 'Rebooting to apply /boot/config.txt changes',
+      message => "Rebooting to apply ${path} changes",
       when    => refreshed,
     }
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,7 +12,9 @@ class pi::config (
   Hash[String[1], Hash] $fragments = {},
   Boolean $reboot = true,
 ) {
-  $path = "${::pi::params::path}/config.txt"
+  include pi::params
+
+  $path = "${pi::params::path}/config.txt"
 
   concat { $path:
     ensure => present,

--- a/manifests/config/fragment.pp
+++ b/manifests/config/fragment.pp
@@ -19,12 +19,12 @@ define pi::config::fragment (
   }
 
   concat::fragment { $name:
-    target  => '/boot/config.txt',
+    target  => $pi::config::path,
     content => $_real_content,
     order   => $order,
   }
 
   if Class['pi::config']['reboot'] {
-    Concat::Fragment[$name] ~> Reboot['/boot/config.txt']
+    Concat::Fragment[$name] ~> Reboot[$pi::config::path]
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,9 @@
+class pi::params {
+  # https://www.raspberrypi.com/documentation/computers/config_txt.html
+  # Prior to Raspberry Pi OS Bookworm, Raspberry Pi OS stored the boot partition at /boot/.
+  if $::facts['os']['name'] == 'Raspbian' and versioncmp($::facts['os']['release']['major'], '12') >= 0 {
+    $path = '/boot/firmware'
+  } else {
+    $path = '/boot'
+  }
+}


### PR DESCRIPTION
As per the [official documentation](https://www.raspberrypi.com/documentation/computers/config_txt.html), the configuration files have been moved from `/boot` to `/boot/firmware`. Please consider amending the modules, by either making the configuration file paths adjustable in hiera, or by auto-selecting the correct path.

Closes #9 